### PR TITLE
Fix duplicate function in proxy_types

### DIFF
--- a/proxy_types.py
+++ b/proxy_types.py
@@ -169,9 +169,3 @@ class DatablockProxy:
             flat_list.extend(child.get_flat_list())
         return flat_list
 
-    def get_flat_list(self):
-        """Returns a flat list of all proxies in the subtree, including self."""
-        flat_list = [self]
-        for child in self.children:
-            flat_list.extend(child.get_flat_list())
-        return flat_list


### PR DESCRIPTION
## Summary
- remove duplicated `get_flat_list` definition

## Testing
- `python -m py_compile proxy_types.py`

------
https://chatgpt.com/codex/tasks/task_e_6880919878fc8330b2988ddff4af60ae